### PR TITLE
Feature / [16] Allow students to view their own grades (backend)

### DIFF
--- a/spec/integration/api/grades_spec.rb
+++ b/spec/integration/api/grades_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'api/grades', type: :request do
   end
 
   path '/api/grades' do
-    get 'List grades (teachers only, scoped to current teacher)' do
+    get 'List grades (students see their own, teachers see theirs)' do
       tags ['Grades']
       produces 'application/json'
       security [bearer_auth: []]
@@ -55,6 +55,23 @@ RSpec.describe 'api/grades', type: :request do
         example 'application/json', :example, {
           error: 'Unauthorized: Teachers only'
         }
+
+        run_test!
+      end
+
+      response '200', 'Grades retrieved for current student' do
+        let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+        let!(:g1) do
+          create(:grade, value: 8, student: student, subject: subject_rec, teacher: teacher)
+        end
+
+        let(:subject_id) { subject_rec.id }
+
+        example 'application/json', :example, [
+          { id: 1, value: 8, student_id: 3, teacher_id: 2, subject_id: 5,
+            created_at: '2025-08-14T13:00:00Z' }
+        ]
 
         run_test!
       end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -14,7 +14,7 @@ security:
 paths:
   "/api/grades":
     get:
-      summary: List grades (teachers only, scoped to current teacher)
+      summary: List grades (students see their own, teachers see theirs)
       tags:
       - - Grades
       security:
@@ -32,7 +32,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: Grades retrieved for current teacher
+          description: Grades retrieved for current student
           content:
             application/json:
               examples:


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_backend/issues/16

Frontend PR: https://github.com/smaria03/eduapp_frontend/pull/23

**Changes**
Allow students to view their own grades filtered by subject.

**Before**
Only teachers could access grades. No support for student-side grade viewing.

**After**
<img width="826" height="639" alt="Screenshot 2025-08-19 at 10 52 43" src="https://github.com/user-attachments/assets/9103f62e-0419-48bf-82d6-4c21607f6dab" />

