### PR TITLE
Fix / [46] Add endpoint to fetch students without a class (backend)

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -73,6 +73,11 @@ module Api
                                   as_json_opts: { only: %i[id name email school_class_id] })
     end
 
+    def students_without_class
+      students = User.where(role: 'student', school_class_id: nil).order(:name)
+      render json: students.as_json(only: %i[id name email])
+    end
+
     def teachers
       render json: User.where(role: 'teacher')
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,5 +42,6 @@ Rails.application.routes.draw do
     delete 'timetable/:id',      to: 'timetables#destroy'
     resources :periods, only: [:index]
     resources :grades, only: %i[index create update destroy]
+    get 'students/without_class', to: 'users#students_without_class'
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_backend/issues/46

Frontend PR: https://github.com/smaria03/eduapp_frontend/pull/24

**Changes**
Added a new backend endpoint /api/students/without_class that returns all students who are not assigned to any class. This uses a non-paginated query and is used on the "Create Class" page to ensure all unassigned students are visible.

**Before**
Only the first 5 students (default pagination limit) were returned in /api/students, and filtering school_class_id === null in the frontend often resulted in empty lists.
<img width="829" height="641" alt="Screenshot 2025-08-19 at 13 19 10" src="https://github.com/user-attachments/assets/a928b486-db80-4e3e-a7e9-9cb29bccc365" />

**After**
<img width="828" height="645" alt="Screenshot 2025-08-19 at 13 21 47" src="https://github.com/user-attachments/assets/4bdf6cd2-8f5a-4a3a-842b-e7fbc426d24f" />

