### PR TITLE
Feature / [63] Allow students to re-submit homework

### DIFF
--- a/app/controllers/api/homework_submissions_controller.rb
+++ b/app/controllers/api/homework_submissions_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module Api
   class HomeworkSubmissionsController < ApplicationController
     before_action :authorize_student!, only: %i[create destroy]
@@ -46,7 +47,8 @@ module Api
       end
 
       if submission.homework.deadline < Time.current
-        return render json: { error: 'Cannot delete after the deadline has passed' }, status: :forbidden
+        return render json: { error: 'Cannot delete after the deadline has passed' },
+                      status: :forbidden
       end
 
       submission.destroy
@@ -56,23 +58,17 @@ module Api
 
     def grade
       submission = HomeworkSubmission.find_by(id: params[:id])
-      return render json: { error: 'Submission not found' }, status: :not_found unless submission
-
-      assignment = submission.homework.assignment
-      unless assignment.teacher_id == current_user.id
-        return render json: { error: 'Unauthorized: Not your homework' }, status: :unauthorized
-      end
-
+      return render_not_found('Submission') unless submission
+      return render_unauthorized unless teacher_owns_submission?(submission)
       if submission.homework.deadline > Time.current
-        return render json: { error: 'You can only grade after the deadline has passed.' }, status: :forbidden
+        return render_forbidden('You can only grade after the deadline has passed.')
       end
 
       if submission.update(grade: params[:grade])
-        create_grade_for_submission(submission, assignment)
+        create_grade_for_submission(submission, submission.homework.assignment)
         render json: { message: 'Grade updated', grade: submission.grade }, status: :ok
       else
-        render json: { error: submission.errors.full_messages.to_sentence },
-               status: :unprocessable_entity
+        render_unprocessable(submission)
       end
     end
 
@@ -187,5 +183,18 @@ module Api
 
       render json: { error: 'Unauthorized: Students or teachers only' }, status: :unauthorized
     end
+
+    def render_unauthorized
+      render json: { error: 'Unauthorized: Not your homework' }, status: :unauthorized
+    end
+
+    def render_unprocessable(record)
+      render json: { error: record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    end
+
+    def teacher_owns_submission?(submission)
+      submission.homework.assignment.teacher_id == current_user.id
+    end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/api/homework_submissions_controller.rb
+++ b/app/controllers/api/homework_submissions_controller.rb
@@ -58,10 +58,10 @@ module Api
 
     def grade
       submission = HomeworkSubmission.find_by(id: params[:id])
-      return render_not_found('Submission') unless submission
+      return render json: { error: 'Submission not found' }, status: :not_found unless submission
       return render_unauthorized unless teacher_owns_submission?(submission)
       if submission.homework.deadline > Time.current
-        return render_forbidden('You can only grade after the deadline has passed.')
+        return render json: { error: 'You can only grade after the deadline has passed.' }, status: :forbidden
       end
 
       if submission.update(grade: params[:grade])

--- a/app/controllers/api/homework_submissions_controller.rb
+++ b/app/controllers/api/homework_submissions_controller.rb
@@ -45,6 +45,10 @@ module Api
         return render json: { error: 'Cannot delete a graded submission' }, status: :forbidden
       end
 
+      if submission.homework.deadline < Time.current
+        return render json: { error: 'Cannot delete after the deadline has passed' }, status: :forbidden
+      end
+
       submission.destroy
 
       render json: { message: 'Homework submission deleted successfully' }, status: :ok
@@ -57,6 +61,10 @@ module Api
       assignment = submission.homework.assignment
       unless assignment.teacher_id == current_user.id
         return render json: { error: 'Unauthorized: Not your homework' }, status: :unauthorized
+      end
+
+      if submission.homework.deadline > Time.current
+        return render json: { error: 'You can only grade after the deadline has passed.' }, status: :forbidden
       end
 
       if submission.update(grade: params[:grade])

--- a/app/controllers/api/homework_submissions_controller.rb
+++ b/app/controllers/api/homework_submissions_controller.rb
@@ -60,8 +60,10 @@ module Api
       submission = HomeworkSubmission.find_by(id: params[:id])
       return render json: { error: 'Submission not found' }, status: :not_found unless submission
       return render_unauthorized unless teacher_owns_submission?(submission)
+
       if submission.homework.deadline > Time.current
-        return render json: { error: 'You can only grade after the deadline has passed.' }, status: :forbidden
+        return render json: { error: 'You can only grade after the deadline has passed.' },
+                      status: :forbidden
       end
 
       if submission.update(grade: params[:grade])

--- a/spec/integration/api/homework_submissions_spec.rb
+++ b/spec/integration/api/homework_submissions_spec.rb
@@ -288,6 +288,14 @@ RSpec.describe 'api/homework_submissions', type: :request do
         required: ['grade']
       }
 
+      let!(:homework) do
+        create(:homework, assignment: assignment).tap do |hw|
+          # rubocop:disable Rails/SkipsModelValidations
+          hw.update_column(:deadline, 1.day.ago)
+          # rubocop:enable Rails/SkipsModelValidations
+        end
+      end
+
       let!(:submission) do
         s = build(:homework_submission, homework: homework, student: student)
         s.file.attach(


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_backend/issues/63

**Changes**
Updated the backend to prevent students from deleting homework submissions after the deadline and to restrict grading until the deadline has passed.

**Before**
Students could delete their submissions at any time, and teachers could grade them even before the deadline.

**After**
<img width="824" height="436" alt="Screenshot 2025-09-01 at 13 45 58" src="https://github.com/user-attachments/assets/99cd66ee-f25e-499b-979f-5a81a97a40d6" />
<img width="820" height="399" alt="Screenshot 2025-09-01 at 13 47 46" src="https://github.com/user-attachments/assets/5fca765b-602a-425d-9b93-0589305b2004" />
