### PR TITLE
Feature / [71] Add missing Swagger documentation

### DIFF
--- a/app/controllers/api/school_classes_controller.rb
+++ b/app/controllers/api/school_classes_controller.rb
@@ -101,6 +101,8 @@ module Api
     end
 
     def graduate_all
+      return unless validate_graduation_params?
+
       label = params[:label]
       classes = SchoolClass.unscoped
                            .includes(:students, :school_class_subjects)
@@ -139,6 +141,18 @@ module Api
     end
 
     private
+
+    def validate_graduation_params?
+      if params[:label].blank?
+        render json: {
+          message: 'Graduation process failed. No classes were updated.',
+          error: 'Label is required'
+        }, status: :unprocessable_entity
+        return false
+      end
+
+      true
+    end
 
     def set_school_class
       @school_class = SchoolClass.find(params[:id])

--- a/spec/integration/api/archives_spec.rb
+++ b/spec/integration/api/archives_spec.rb
@@ -1,0 +1,176 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/archives', type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:student) { create(:user, :student) }
+
+  path '/api/school_class_archives/labels' do
+    get 'List all archive labels (admin only)' do
+      tags ['Archives']
+      produces 'application/json'
+      security [bearer_auth: []]
+
+      let(:Authorization) { "Bearer #{generate_token_for(admin)}" }
+
+      response '200', 'Labels listed' do
+        example 'application/json', :example, {
+          labels: %w[2022-2023 2023-2024]
+        }
+        run_test!
+      end
+
+      response '401', 'Unauthorized (not admin)' do
+        let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+        example 'application/json', :example, {
+          error: 'Unauthorized: Admins only'
+        }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/school_class_archives/by_label/{label}' do
+    get 'Get all archived classes for a specific label (admin only)' do
+      tags ['Archives']
+      produces 'application/json'
+      security [bearer_auth: []]
+      parameter name: :label, in: :path, type: :string, description: 'Archive label'
+
+      let(:Authorization) { "Bearer #{generate_token_for(admin)}" }
+      let(:label) { '2023-2024' }
+
+      response '200', 'Archived classes returned' do
+        example 'application/json', :example, [
+          {
+            id: 1,
+            label: '2023-2024',
+            archived_at: '2024-06-15T12:00:00Z',
+            school_class: {
+              id: 5,
+              current_name: '11A',
+              archived_name: '10A'
+            }
+          }
+        ]
+        run_test!
+      end
+
+      response '401', 'Unauthorized (not admin)' do
+        let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+        example 'application/json', :example, {
+          error: 'Unauthorized: Admins only'
+        }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/school_class_archives/{id}' do
+    get 'Get full details of a specific archive (admin only)' do
+      tags ['Archives']
+      produces 'application/json'
+      security [bearer_auth: []]
+      parameter name: :id, in: :path, type: :integer
+
+      let(:Authorization) { "Bearer #{generate_token_for(admin)}" }
+      let(:school_class) { create(:school_class, name: '10A') }
+
+      let(:id) do
+        create(
+          :school_class_archive,
+          school_class: school_class,
+          label: '2023-2024',
+          data: {
+            class_name: '10A',
+            students: [{ id: 1, name: 'Prenume1 Nume1' }],
+            assignments: [{ subject_id: 1, subject_name: 'Math' }]
+          }
+        ).id
+      end
+
+      response '200', 'Archive found' do
+        example 'application/json', :example, {
+          id: 1,
+          label: '2023-2024',
+          archived_at: '2024-06-15T12:00:00Z',
+          school_class_id: 5,
+          data: {
+            class_name: '10A',
+            students: [
+              { id: 1, name: 'Prenume1 Nume1' },
+              { id: 2, name: 'Prenume2 Nume2' }
+            ],
+            assignments: [
+              { subject_id: 3, subject_name: 'Math' },
+              { subject_id: 4, subject_name: 'Biology' }
+            ]
+          }
+        }
+
+        run_test!
+      end
+
+      response '404', 'Archive not found' do
+        let(:id) { -1 }
+
+        example 'application/json', :example, {
+          error: 'Archive not found'
+        }
+
+        run_test!
+      end
+
+      response '401', 'Unauthorized (not admin)' do
+        let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/student_archives' do
+    get 'Get student\'s personal archive (student only)' do
+      tags ['Archives']
+      produces 'application/json'
+      security [bearer_auth: []]
+
+      let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+      response '200', 'Archive returned' do
+        example 'application/json', :example, {
+          '2022-2023': {
+            class_name: '10A',
+            subjects: [
+              {
+                subject_id: 1,
+                subject_name: 'Math',
+                grades: [{ id: 1, value: 8, created_at: '2024-06-10T00:00:00Z' }],
+                present_count: 40,
+                absent_count: 5
+              }
+            ]
+          }
+        }
+        run_test!
+      end
+
+      response '401', 'Unauthorized (not student)' do
+        let(:Authorization) { "Bearer #{generate_token_for(admin)}" }
+
+        example 'application/json', :example, {
+          error: 'Unauthorized: Students only'
+        }
+
+        run_test!
+      end
+    end
+  end
+end
+
+def generate_token_for(user)
+  Warden::JWTAuth::UserEncoder.new.call(user, :user, nil).first
+end

--- a/spec/integration/api/reports_spec.rb
+++ b/spec/integration/api/reports_spec.rb
@@ -1,0 +1,130 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/reports', type: :request do
+  let(:teacher) { create(:user, :teacher) }
+  let(:student) { create(:user, :student) }
+  let(:subject_rec) { create(:subject) }
+  let(:school_class) { create(:school_class) }
+  let(:assignment) do
+    create(:school_class_subject, teacher: teacher, subject: subject_rec,
+                                  school_class: school_class)
+  end
+  let(:Authorization) { "Bearer #{generate_token_for(teacher)}" }
+
+  before do
+    assignment
+    student.update!(school_class: school_class)
+  end
+
+  path '/api/class_reports/{id}' do
+    get 'Returns detailed report for a class (teacher only)' do
+      tags ['Reports']
+      produces 'application/json'
+      security [bearer_auth: []]
+      parameter name: :id, in: :path, type: :integer, description: 'Class ID'
+
+      let(:id) { school_class.id }
+
+      response '200', 'Class report retrieved' do
+        example 'application/json', :example, {
+          class_name: '10B',
+          students_count: 20,
+          subjects: [
+            {
+              subject: 'Math',
+              grades: {
+                per_student: [
+                  { name: 'Prenume Nume', average: 8.25 }
+                ],
+                class_average: 7.6
+              },
+              attendance: {
+                present: 45,
+                absent: 5
+              },
+              homeworks: [
+                { title: 'Tema 1', submitted: '18/20', average_grade: 7.5 }
+              ],
+              quizzes: [
+                { title: 'Test 1', submitted: '19/20', average_score: 8.0 }
+              ]
+            }
+          ]
+        }
+        run_test!
+      end
+
+      response '401', 'Unauthorized (not a teacher)' do
+        let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+        example 'application/json', :example, {
+          error: 'Unauthorized: Teachers only'
+        }
+
+        run_test!
+      end
+
+      response '401', 'Teacher not assigned to class' do
+        let(:Authorization) { "Bearer #{generate_token_for(create(:user, :teacher))}" }
+
+        example 'application/json', :example, {
+          error: 'Unauthorized: You don’t teach this class'
+        }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/student_reports' do
+    get 'Returns personal report for a student (student only)' do
+      tags ['Reports']
+      produces 'application/json'
+      security [bearer_auth: []]
+
+      let(:Authorization) { "Bearer #{generate_token_for(student)}" }
+
+      response '200', 'Student report retrieved' do
+        example 'application/json', :example, {
+          student_name: 'Prenume Nume',
+          class_name: '10B',
+          overall_average: 8.2,
+          class_position: 4,
+          total_absences: 3,
+          subjects: [
+            {
+              subject: 'Math',
+              average: 8.5,
+              absences: 1,
+              homeworks: {
+                submitted: 3,
+                total: 4
+              },
+              quizzes: [
+                {
+                  quiz_title: 'Test 1',
+                  score: 9.0
+                }
+              ]
+            }
+          ]
+        }
+        run_test!
+      end
+
+      response '401', 'Unauthorized (not a student)' do
+        let(:Authorization) { "Bearer #{generate_token_for(teacher)}" }
+
+        example 'application/json', :example, {
+          error: 'Unauthorized: Students only'
+        }
+
+        run_test!
+      end
+    end
+  end
+end
+
+def generate_token_for(user)
+  Warden::JWTAuth::UserEncoder.new.call(user, :user, nil).first
+end

--- a/spec/integration/api/school_classes_spec.rb
+++ b/spec/integration/api/school_classes_spec.rb
@@ -281,6 +281,68 @@ RSpec.describe 'api/school_classes', type: :request do
       end
     end
   end
+
+  path '/api/school_classes/graduation' do
+    patch 'Graduate all classes and archive data (admin only)' do
+      tags ['SchoolClasses']
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+
+      parameter name: :payload, in: :body, required: true, schema: {
+        type: :object,
+        properties: {
+          label: { type: :string, example: '2024-2025' }
+        },
+        required: ['label']
+      }
+
+      response '200', 'Graduation completed successfully' do
+        let(:payload) { { label: '2024-2025' } }
+
+        metadata[:response][:content] = {
+          'application/json' => {
+            example: {
+              message: 'Graduation process completed successfully.',
+              graduated_classes: %w[10A 11B]
+            }
+          }
+        }
+
+        run_test!
+      end
+
+      response '422', 'Graduation process failed' do
+        let(:payload) { { label: '' } }
+
+        metadata[:response][:content] = {
+          'application/json' => {
+            example: {
+              message: 'Graduation process failed. No classes were updated.',
+              error: 'Label is required'
+            }
+          }
+        }
+
+        run_test!
+      end
+
+      response '401', 'Unauthorized (non-admin)' do
+        let(:Authorization) { "Bearer #{generate_token_for(create(:user, :teacher))}" }
+        let(:payload) { { label: '2024-2025' } }
+
+        metadata[:response][:content] = {
+          'application/json' => {
+            example: {
+              error: 'Unauthorized: Admins only'
+            }
+          }
+        }
+
+        run_test!
+      end
+    end
+  end
 end
 
 def generate_token_for(user)

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -12,6 +12,150 @@ components:
 security:
 - bearer_auth: []
 paths:
+  "/api/school_class_archives/labels":
+    get:
+      summary: List all archive labels (admin only)
+      tags:
+      - - Archives
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: Labels listed
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    labels:
+                    - 2022-2023
+                    - 2023-2024
+        '401':
+          description: Unauthorized (not admin)
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    error: 'Unauthorized: Admins only'
+  "/api/school_class_archives/by_label/{label}":
+    get:
+      summary: Get all archived classes for a specific label (admin only)
+      tags:
+      - - Archives
+      security:
+      - bearer_auth: []
+      parameters:
+      - name: label
+        in: path
+        description: Archive label
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Archived classes returned
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                  - id: 1
+                    label: 2023-2024
+                    archived_at: '2024-06-15T12:00:00Z'
+                    school_class:
+                      id: 5
+                      current_name: 11A
+                      archived_name: 10A
+        '401':
+          description: Unauthorized (not admin)
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    error: 'Unauthorized: Admins only'
+  "/api/school_class_archives/{id}":
+    get:
+      summary: Get full details of a specific archive (admin only)
+      tags:
+      - - Archives
+      security:
+      - bearer_auth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Archive found
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    id: 1
+                    label: 2023-2024
+                    archived_at: '2024-06-15T12:00:00Z'
+                    school_class_id: 5
+                    data:
+                      class_name: 10A
+                      students:
+                      - id: 1
+                        name: Prenume1 Nume1
+                      - id: 2
+                        name: Prenume2 Nume2
+                      assignments:
+                      - subject_id: 3
+                        subject_name: Math
+                      - subject_id: 4
+                        subject_name: Biology
+        '404':
+          description: Archive not found
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    error: Archive not found
+        '401':
+          description: Unauthorized (not admin)
+  "/api/student_archives":
+    get:
+      summary: Get student's personal archive (student only)
+      tags:
+      - - Archives
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: Archive returned
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    2022-2023:
+                      class_name: 10A
+                      subjects:
+                      - subject_id: 1
+                        subject_name: Math
+                        grades:
+                        - id: 1
+                          value: 8
+                          created_at: '2024-06-10T00:00:00Z'
+                        present_count: 40
+                        absent_count: 5
+        '401':
+          description: Unauthorized (not student)
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    error: 'Unauthorized: Students only'
   "/api/attendances":
     get:
       summary: List all attendances (teacher/student)
@@ -375,7 +519,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: Filtered by subject_id
+          description: Returns empty list for teacher without homework_id
           content:
             application/json:
               examples:
@@ -389,13 +533,13 @@ paths:
                     file_attached: true
                     grade:
         '401':
-          description: Unauthorized (non-student)
+          description: Unauthenticated
           content:
             application/json:
               examples:
                 example:
                   value:
-                    error: 'Unauthorized: Students only'
+                    error: You need to sign in or sign up before continuing.
     post:
       summary: Submit homework (student uploads a file)
       tags:
@@ -1052,6 +1196,94 @@ paths:
                 not_found:
                   value:
                     error: Quiz not found
+  "/api/class_reports/{id}":
+    get:
+      summary: Returns detailed report for a class (teacher only)
+      tags:
+      - - Reports
+      security:
+      - bearer_auth: []
+      parameters:
+      - name: id
+        in: path
+        description: Class ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Class report retrieved
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    class_name: 10B
+                    students_count: 20
+                    subjects:
+                    - subject: Math
+                      grades:
+                        per_student:
+                        - name: Prenume Nume
+                          average: 8.25
+                        class_average: 7.6
+                      attendance:
+                        present: 45
+                        absent: 5
+                      homeworks:
+                      - title: Tema 1
+                        submitted: 18/20
+                        average_grade: 7.5
+                      quizzes:
+                      - title: Test 1
+                        submitted: 19/20
+                        average_score: 8.0
+        '401':
+          description: Teacher not assigned to class
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    error: 'Unauthorized: You don’t teach this class'
+  "/api/student_reports":
+    get:
+      summary: Returns personal report for a student (student only)
+      tags:
+      - - Reports
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: Student report retrieved
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    student_name: Prenume Nume
+                    class_name: 10B
+                    overall_average: 8.2
+                    class_position: 4
+                    total_absences: 3
+                    subjects:
+                    - subject: Math
+                      average: 8.5
+                      absences: 1
+                      homeworks:
+                        submitted: 3
+                        total: 4
+                      quizzes:
+                      - quiz_title: Test 1
+                        score: 9.0
+        '401':
+          description: Unauthorized (not a student)
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    error: 'Unauthorized: Students only'
   "/api/school_classes/{school_class_id}/subjects/{subject_id}":
     parameters:
     - name: school_class_id
@@ -1445,6 +1677,49 @@ paths:
             application/json:
               example:
                 error: Student does not belong to this class
+  "/api/school_classes/graduation":
+    patch:
+      summary: Graduate all classes and archive data (admin only)
+      tags:
+      - - SchoolClasses
+      security:
+      - bearer_auth: []
+      parameters: []
+      responses:
+        '200':
+          description: Graduation completed successfully
+          content:
+            application/json:
+              example:
+                message: Graduation process completed successfully.
+                graduated_classes:
+                - 10A
+                - 11B
+        '422':
+          description: Graduation process failed
+          content:
+            application/json:
+              example:
+                message: Graduation process failed. No classes were updated.
+                error: Label is required
+        '401':
+          description: Unauthorized (non-admin)
+          content:
+            application/json:
+              example:
+                error: 'Unauthorized: Admins only'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                label:
+                  type: string
+                  example: 2024-2025
+              required:
+              - label
+        required: true
   "/api/students":
     get:
       summary: Get list of all students


### PR DESCRIPTION
Fixes: https://github.com/smaria03/eduapp_backend/issues/71

**Changes**
Add missing Swagger documentation for API routes

**Before**
Some routes were not visible in the Swagger interface.

**After**
All routes are now documented in Swagger.